### PR TITLE
Add Sqlite skeleton

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -1,6 +1,7 @@
 // TODO:
 // - Make `store_event` take multiple inputs that are stored together in the same transaction.
 // - Implement this for Postgres in addition to Sqlite. Postgres will likely have a native async backend, so we should have the trait be async and internally `spawn_blocking` for use of non async rusqlite.
+// - Think about whether the trait should be Send + Sync and whether methods should take mutable Self.
 
 use anyhow::Result;
 use solabi::{abi::EventDescriptor, value::Value};
@@ -23,7 +24,7 @@ pub trait Database {
     /// Errors:
     ///
     /// - A table for `name` already exists with an incompatible event signature.
-    fn prepare_event(name: &str, event: &EventDescriptor) -> Result<()>;
+    fn prepare_event(&mut self, name: &str, event: &EventDescriptor) -> Result<()>;
 
     /// Store an event in the database.
     ///
@@ -32,6 +33,7 @@ pub trait Database {
     /// - `prepare_event` has not been successfully called with this `name`.
     /// - `fields` do not match the event signature specified in the successful call to `prepare_event` with this `name`.
     fn store_event(
+        &mut self,
         name: &str,
         block_number: u64,
         log_index: u64,

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -1,10 +1,69 @@
-// TODO:
-// - Implement `Database` trait.
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::Connection;
+use solabi::abi::EventDescriptor;
+
+use crate::database::Database;
+
+pub struct Sqlite {
+    _connection: Connection,
+    events: HashMap<String, EventDescriptor>,
+}
+
+impl Sqlite {
+    pub fn _new(connection: Connection) -> Self {
+        Self {
+            _connection: connection,
+            events: Default::default(),
+        }
+    }
+
+    #[cfg(test)]
+    /// Create a temporary in memory database for tests.
+    pub fn new_for_test() -> Self {
+        Self::_new(Connection::open_in_memory().unwrap())
+    }
+
+    #[cfg(test)]
+    /// Access to the connection. Useful for tests.
+    pub fn _connection(&self) -> &Connection {
+        &self._connection
+    }
+}
+
+impl Database for Sqlite {
+    fn prepare_event(&mut self, name: &str, event: &EventDescriptor) -> Result<()> {
+        if let Some(existing) = self.events.get(name) {
+            if event != existing {
+                return Err(anyhow!(
+                    "event {name} already exists with different signature"
+                ));
+            }
+            return Ok(());
+        }
+        todo!("check that matching table exists or create it if not")
+    }
+
+    fn store_event(
+        &mut self,
+        name: &str,
+        _block_number: u64,
+        _log_index: u64,
+        _address: &[u8; 20],
+        _fields: &[solabi::value::Value],
+    ) -> Result<()> {
+        let _event = self.events.get(name).context("unprepared event")?;
+        todo!("try to parse fields according to event descriptor")
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn rusqlite_works() {
-        rusqlite::Connection::open_in_memory().unwrap();
+    fn new_for_test() {
+        Sqlite::new_for_test();
     }
 }


### PR DESCRIPTION
Started implementing Sqlite. Noticed some mistakes in the Database trait. I decided that for now, users of the struct have to Arc-Mutex it themself if they want to use it that way. This is going to be inefficient with an implementation that can do this natively like with Postgres but until then this is more practical.