### PR TITLE
Ethereum Log Decoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "hex-literal",
  "rusqlite",
  "serde",
  "solabi",
@@ -232,7 +233,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95bb7621599236a07e6da2fd637dad0daad962bfd9d144e840495493f0bb958"
 dependencies = [
+ "ethaddr-macros",
  "serde",
+ "sha3",
+]
+
+[[package]]
+name = "ethaddr-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1f104cb671aa4f3c99fea5ad19389f847a36078aa0281d1069e939bbfb8500"
+dependencies = [
  "sha3",
 ]
 
@@ -242,7 +253,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b8d53c484fe86fff930cc7362fcdb6dfa82aeb4fb49687647d88a2e964381b"
 dependencies = [
+ "ethdigest-macros",
  "serde",
+ "sha3",
+]
+
+[[package]]
+name = "ethdigest-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd434880980950731e2a9eaf9b76dd32d4c0eddf616d9ae4f7884f12994e15a8"
+dependencies = [
  "sha3",
 ]
 
@@ -252,8 +273,15 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 dependencies = [
+ "ethnum-macros",
  "serde",
 ]
+
+[[package]]
+name = "ethnum-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba69ba11ab069d2f946bb46a199630ad6680fa3ecdc87a62c7477f9916095841"
 
 [[package]]
 name = "ethprim"
@@ -333,6 +361,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "idna"
@@ -568,9 +602,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "solabi"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47a6a81bf3f8e02f67948ab51268bd0d4837631d4c0fc87065746d37b9761ad"
+checksum = "d32d91770eb2332ca87ff7df4a6e1b5014e6b3fe4d56ff47a77212eb2a56508b"
 dependencies = [
  "ethprim",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,11 @@ anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 rusqlite = "0.29"
 serde = { version = "1", features = ["derive"] }
-solabi = "0.0.3"
+solabi = { version = "0.0.4", features = ["macros"] }
 toml = "0.7"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = { version = "2", features = ["serde"] }
+
+[dev-dependencies]
+hex-literal = "0.4"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,104 @@
+//! Module implementing event decoding logic. This module is responsible for
+//! taking an Ethereum log and decoding it into event fields.
+
+use anyhow::Result;
+use solabi::{
+    abi::EventDescriptor,
+    log::Log,
+    value::{EventEncoder, Value},
+};
+
+pub struct Decoder {
+    encoder: EventEncoder,
+}
+
+impl Decoder {
+    pub fn new(event: &EventDescriptor) -> Result<Self> {
+        anyhow::ensure!(!event.anonymous, "anonymous events are not supported");
+        let encoder = EventEncoder::new(event)?;
+
+        Ok(Self { encoder })
+    }
+
+    pub fn decode(&self, log: &Log) -> Result<Vec<Value>> {
+        let fields = self.encoder.decode(log)?;
+        Ok(fields)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+    use solabi::{
+        ethprim::{address, keccak, uint},
+        log::Topics,
+        value::Uint,
+    };
+
+    #[test]
+    fn no_anonymous_events() {
+        assert!(Decoder::new(
+            &EventDescriptor::parse_declaration("event Foo() anonymous;").unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn decode_event() {
+        let decoder = Decoder::new(
+            &EventDescriptor::parse_declaration(
+                "event Transfer(address indexed to, address indexed from, uint256 value)",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let log = Log {
+            topics: Topics::from([
+                keccak!("Transfer(address,address,uint256)").0,
+                hex!("0000000000000000000000000101010101010101010101010101010101010101"),
+                hex!("0000000000000000000000000202020202020202020202020202020202020202"),
+            ]),
+            data: hex!("0000000000000000000000000000000000000000000000003a4965bf58a40000")[..]
+                .into(),
+        };
+
+        assert_eq!(
+            decoder.decode(&log).unwrap(),
+            [
+                Value::Address(address!("0x0101010101010101010101010101010101010101")),
+                Value::Address(address!("0x0202020202020202020202020202020202020202")),
+                Value::Uint(Uint::new(256, uint!("4_200_000_000_000_000_000")).unwrap()),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_primitive_indexed_field() {
+        let decoder = Decoder::new(
+            &EventDescriptor::parse_declaration(
+                "event Foo(string indexed note, bool indexed flag);",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let log = Log {
+            topics: Topics::from([
+                keccak!("Foo(string,bool)").0,
+                keccak!("hello").0,
+                hex!("0000000000000000000000000000000000000000000000000000000000000001"),
+            ]),
+            data: vec![].into(),
+        };
+
+        assert_eq!(
+            decoder.decode(&log).unwrap(),
+            [
+                Value::FixedBytes(keccak!("hello").0.into()),
+                Value::Bool(true),
+            ]
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 mod config;
 mod database;
+mod decoder;
 mod sqlite;
 
-use self::config::Config;
+use self::{config::Config, decoder::Decoder};
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -19,4 +20,13 @@ fn main() {
     let config = Config::load(&args.config).expect("failed to load configuration");
 
     tracing::info!("{config:#?}");
+
+    let decoders = config
+        .events
+        .iter()
+        .map(|event| Decoder::new(&event.signature).expect("unsupported event signature"))
+        .collect::<Vec<_>>();
+    if let Some(decoder) = decoders.first() {
+        tracing::debug!("{:?}", decoder.decode(&Default::default()));
+    }
 }


### PR DESCRIPTION
It turns out, `solabi` already has the required functionality to turn an Ethereum log into decoded event fields for a given `EventDescriptor` :tada:. This PR just creates a simple wrapper type around the `solabi` logic for use in `arak`.

Added some unit tests to demonstrate expected `Decoder` behaviour.

### `solabi` Fixes

This PR also bumps the `solabi` crate which contains some fixes - notably:
- Improved handling for non-primitive indexed fields: https://github.com/nlordell/solabi-rs/commit/de75c6947fef5fa510ec33f00998b63b43a01ee4
- `std::error::Error` implementation for additional error types: https://github.com/nlordell/solabi-rs/commit/7989deb511ea49002d6d95a6ca569913df63b366