### PR TITLE
Small CI changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
     - name: Lint
-      run: cargo fmt --check && cargo clippy --verbose
-    - name: Run tests
+      run: cargo fmt --check && cargo clippy --all-targets --verbose
+    - name: Test
       run: cargo test --verbose


### PR DESCRIPTION
- Do linting before building because it's faster.
- Clippy all targets (test)
- Remove build step because it doesn't check anything extra.