### PR TITLE
Hook it All Up, And Fix Event Name Sanitation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,13 @@ async fn main() -> Result<()> {
     let config = Config::load(&args.config).context("failed to load configuration")?;
 
     let eth = ethrpc::http::Client::new(config.ethrpc);
-    let _database = sqlite::Sqlite::open(
+    let database = sqlite::Sqlite::open(
         &config
             .database
             .to_file_path()
             .ok()
             .context("database must be a file:// URL")?,
-    );
-    let database = database::Dummy::default();
+    )?;
 
     Indexer::create(eth, database, config.events)?
         .run(indexer::Run {


### PR DESCRIPTION
This PR hooks up the indexer to the actual DB (so you can run it against SQLite now :tada:) and fixes some small issues with event name sanitation:
- `_` are allowed, so add it to the filter check
- The event name was not being sanitized when writing and reading event blocks, causing unexpected errors.