### PR TITLE
Implement column names following field names

### DIFF
--- a/src/database/event_to_tables.rs
+++ b/src/database/event_to_tables.rs
@@ -1,0 +1,396 @@
+//! Conversion of `EventDescriptor` into SQL schema
+//!
+//! This module turns an `EventDescriptor` into an SQL schema by providing table and column names. How `ValueKind`s are mapped to SQL types is up to the specific database.
+
+use anyhow::{anyhow, Result};
+use solabi::{
+    abi::{EventDescriptor, Field},
+    ValueKind,
+};
+
+use super::{
+    event_visitor::{visit_field, VisitKind},
+    keywords::KEYWORDS,
+};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Tables<'a> {
+    pub primary: Table<'a>,
+    pub dynamic_arrays: Vec<Table<'a>>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Table<'a> {
+    /// The table name includes a sanitized version of the original event name.
+    pub name: String,
+    pub columns: Vec<Column<'a>>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Column<'a> {
+    // leaf kind
+    pub kind: &'a ValueKind,
+    pub name: String,
+}
+
+pub fn event_to_tables<'a>(name: &str, event: &'a EventDescriptor) -> Result<Tables<'a>> {
+    // TODO:
+    // - Handle indexed fields.
+
+    // To avoid later confusion, force the user provided event name to be valid without change.
+    let sanitized = sanitize_name(name);
+    if sanitized != name {
+        return Err(anyhow!(
+            "Event name '{name}' is not valid. Try '{sanitized}'."
+        ));
+    }
+    let name = sanitized;
+
+    // The database reserves tables starting with underscore for internal use. A user provided event table name could conflict with that.
+    if name.starts_with('_') {
+        return Err(anyhow!(
+            "Event '{name}' starts with an underscore, which isn't allowed."
+        ));
+    }
+
+    // Nested dynamic arrays are rare and hard to handle. The recursive visiting code and SQL schema becomes more complicated. Handle this properly later.
+    for input in &event.inputs {
+        if has_nested_dynamic_arrays(&input.field) {
+            return Err(anyhow!(
+                "Event contains a dynamic array inside of a dynamic array. This isn't supported."
+            ));
+        }
+    }
+
+    let mut primary = Table {
+        name: name.clone(),
+        columns: Default::default(),
+    };
+    let mut dynamic_arrays = Vec::new();
+    for input in &event.inputs {
+        handle_field_simple_names(&name, &mut primary, &mut dynamic_arrays, &input.field);
+    }
+    Ok(Tables {
+        primary,
+        dynamic_arrays,
+    })
+}
+
+fn has_nested_dynamic_arrays(field: &Field) -> bool {
+    let mut level: u32 = 0;
+    let mut max_level: u32 = 0;
+    let mut visitor = |visit: VisitKind| match visit {
+        VisitKind::ArrayStart(_) => {
+            level += 1;
+            max_level = std::cmp::max(max_level, level);
+        }
+        VisitKind::ArrayEnd => level -= 1,
+        VisitKind::TupleStart(_)
+        | VisitKind::TupleEnd
+        | VisitKind::FixedArrayStart(..)
+        | VisitKind::FixedArrayEnd
+        | VisitKind::Leaf(..) => (),
+    };
+    visit_field(&mut visitor, field);
+    max_level > 1
+}
+
+fn handle_field_simple_names<'a>(
+    event_name: &str,
+    primary: &mut Table<'a>,
+    dynamic_arrays: &mut Vec<Table<'a>>,
+    field: &'a Field,
+) {
+    let mut dynamic_array: Option<usize> = None;
+    let mut visitor = move |value: VisitKind<'a>| match value {
+        VisitKind::ArrayStart(name) => {
+            let index = dynamic_arrays.len();
+            dynamic_array = Some(index);
+            let name = if name.is_empty() { "array" } else { name };
+            dynamic_arrays.push(Table {
+                name: sanitize_name(&format!("{event_name}_{name}_{index}")),
+                columns: Default::default(),
+            });
+        }
+        VisitKind::ArrayEnd => {
+            dynamic_array = None;
+        }
+        VisitKind::Leaf(kind, name) => {
+            let table = match dynamic_array {
+                Some(index) => &mut dynamic_arrays[index],
+                None => primary,
+            };
+            let name = if name.is_empty() { "field" } else { name };
+            table.columns.push(Column {
+                kind,
+                name: sanitize_name(&format!("{name}_{}", table.columns.len())),
+            });
+        }
+        _ => (),
+    };
+    visit_field(&mut visitor, field);
+}
+
+fn sanitize_name(name: &str) -> String {
+    let sanitized = sanitize_name_(name);
+    assert_eq!(sanitize_name_(&sanitized), sanitized);
+    sanitized
+}
+
+fn sanitize_name_(name: &str) -> String {
+    let is_allowed_character = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    let mut result: String = name.chars().filter(|c| is_allowed_character(*c)).collect();
+    if result.is_empty() || !is_allowed_character(result.chars().next().unwrap()) {
+        result.insert(0, '_');
+    }
+    let is_keyword = |s: &str| {
+        let lowercase = s.to_ascii_lowercase();
+        KEYWORDS.iter().any(|word| *word == lowercase)
+    };
+    if is_keyword(&result) {
+        result.push('_');
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ValueKind as VK;
+
+    /// Helper type to make expected tables struct terser to define in tests.
+    type TestTables<'a> = &'a [(&'a str, &'a [(&'a ValueKind, &'a str)])];
+
+    fn tables(tables: TestTables<'_>) -> Tables<'_> {
+        fn columns<'a>(columns: &'a [(&'a VK, &'a str)]) -> Vec<Column<'a>> {
+            columns
+                .iter()
+                .map(|(kind, name)| Column {
+                    kind,
+                    name: name.to_string(),
+                })
+                .collect()
+        }
+
+        let primary = tables[0];
+        let rest = &tables[1..];
+        Tables {
+            primary: Table {
+                name: primary.0.to_string(),
+                columns: columns(primary.1),
+            },
+            dynamic_arrays: rest
+                .iter()
+                .map(|(table_name, columns_)| Table {
+                    name: table_name.to_string(),
+                    columns: columns(columns_),
+                })
+                .collect(),
+        }
+    }
+
+    fn assert_tables(event: &str, expected: TestTables) {
+        let expected = tables(expected);
+        let event = EventDescriptor::parse_declaration(event).unwrap();
+        let tables = event_to_tables("event", &event).unwrap();
+        assert_eq!(
+            tables, expected,
+            "actual: {tables:#?} !=\nexpected: {expected:#?}"
+        );
+    }
+
+    #[test]
+    fn with_anonymous() {
+        let event = r#"
+event Event(
+    bool b0,
+    bool,
+    address a0,
+    bool
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b0_0"),
+                (&VK::Bool, "field_1"),
+                (&VK::Address, "a0_2"),
+                (&VK::Bool, "field_3"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn anonymous_tuple() {
+        let event = r#"
+event Event(
+    bool b0,
+    (
+        bool b0,
+        bool b1
+    ),
+    address a0
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b0_0"),
+                (&VK::Bool, "b0_1"),
+                (&VK::Bool, "b1_2"),
+                (&VK::Address, "a0_3"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn named_tuple() {
+        let event = r#"
+event Event(
+    bool b0,
+    (
+        bool b0,
+        bool b1
+    ) my_bools,
+    address a0
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b0_0"),
+                (&VK::Bool, "b0_1"),
+                (&VK::Bool, "b1_2"),
+                (&VK::Address, "a0_3"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn fixed_array() {
+        let event = r#"
+event Event(
+    bool b0,
+    bool b1,
+    bool[2] foo,
+    address a0
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b0_0"),
+                (&VK::Bool, "b1_1"),
+                (&VK::Bool, "foo_2"),
+                (&VK::Bool, "foo_3"),
+                (&VK::Address, "a0_4"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn dynamic_array() {
+        let event = r#"
+event Event(
+    bool b0,
+    bool[] foo,
+    address a0
+  )
+"#;
+        let expected: TestTables = &[
+            ("event", &[(&VK::Bool, "b0_0"), (&VK::Address, "a0_1")]),
+            ("event_foo_0", &[(&VK::Bool, "foo_0")]),
+        ];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn dynamic_array_tuple() {
+        let event = r#"
+event Event(
+    bool b0,
+    (bool bar)[] foo,
+    address a0
+  )
+"#;
+        let expected: TestTables = &[
+            ("event", &[(&VK::Bool, "b0_0"), (&VK::Address, "a0_1")]),
+            ("event_foo_0", &[(&VK::Bool, "bar_0")]),
+        ];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn nested_tuples() {
+        let event = r#"
+event Event(
+    bool b0,
+    (
+        bool b0,
+        (
+            bool,
+            bool
+        ) inner,
+        bool b1
+    ) outer
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b0_0"),
+                (&VK::Bool, "b0_1"),
+                (&VK::Bool, "field_2"),
+                (&VK::Bool, "field_3"),
+                (&VK::Bool, "b1_4"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn nested_fixed_array() {
+        let event = r#"
+event Event(
+    bool[2][3] b
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "b_0"),
+                (&VK::Bool, "b_1"),
+                (&VK::Bool, "b_2"),
+                (&VK::Bool, "b_3"),
+                (&VK::Bool, "b_4"),
+                (&VK::Bool, "b_5"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+
+    #[test]
+    fn nested_fixed_array_and_tuple() {
+        let event = r#"
+event Event(
+    (bool, bool b1, (bool b2) inner_tuple)[1][2] array0
+  )
+"#;
+        let expected: TestTables = &[(
+            "event",
+            &[
+                (&VK::Bool, "field_0"),
+                (&VK::Bool, "b1_1"),
+                (&VK::Bool, "b2_2"),
+                (&VK::Bool, "field_3"),
+                (&VK::Bool, "b1_4"),
+                (&VK::Bool, "b2_5"),
+            ],
+        )];
+        assert_tables(event, expected);
+    }
+}

--- a/src/database/event_visitor.rs
+++ b/src/database/event_visitor.rs
@@ -1,37 +1,75 @@
+//! Event field iteration
+//!
+//! This module is for iterating over the fields of events in a deterministic way.
+
 // TODO:
 // - Would be nicer as iterators.
 
-use solabi::value::{Value, ValueKind};
+use solabi::{
+    abi::Field,
+    value::{Value, ValueKind},
+};
 
+/// The `&str` refers to the name of a field. It works in the following way:
+/// - For named values it is the name . Examples: `bool my_bool`, `bool[] my_bools`
+/// - For anonymous values it is empty. Example: `bool`
+/// - For fixed arrays and dynamic arrays, the name of the array if forwarded into the inner types. When a tuple is reached the forwarded name is dropped.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum VisitKind<'a> {
-    ArrayStart,
+    ArrayStart(&'a str),
     ArrayEnd,
-    Value(&'a ValueKind),
+    TupleStart(&'a str),
+    TupleEnd,
+    FixedArrayStart(usize, &'a str),
+    FixedArrayEnd,
+    Leaf(&'a ValueKind, &'a str),
 }
 
-/// Visit all leaf and dynamic array values in the top level value in a deterministic order.
-///
-/// Does not visit tuples and fixed arrays because the inner values are treated in a flattened way.
-///
-/// Does not visit arrays because they are converted to the start and end enum kinds.
-pub fn visit_kind<'a>(value: &'a ValueKind, visitor: &mut impl FnMut(VisitKind<'a>)) {
-    match value {
+pub fn visit_field<'a>(visitor: &mut impl FnMut(VisitKind<'a>), field: &'a Field) {
+    visit_kind(
+        visitor,
+        &field.kind,
+        &field.name,
+        field.components.as_deref().unwrap_or_default(),
+    );
+}
+
+pub fn visit_kind<'a>(
+    visitor: &mut impl FnMut(VisitKind<'a>),
+    kind: &'a ValueKind,
+    name: &'a str,
+    components: &'a [Field],
+) {
+    match kind {
         ValueKind::Tuple(values) => {
-            for value in values {
-                visit_kind(value, visitor);
+            visitor(VisitKind::TupleStart(name));
+            assert_eq!(values.len(), components.len());
+            for (kind, field) in values.iter().zip(components) {
+                visit_kind(
+                    visitor,
+                    kind,
+                    &field.name,
+                    field.components.as_deref().unwrap_or_default(),
+                );
             }
+            visitor(VisitKind::TupleEnd);
         }
-        ValueKind::FixedArray(length, value) => {
+        ValueKind::FixedArray(length, kind) => {
+            visitor(VisitKind::FixedArrayStart(*length, name));
             for _ in 0..*length {
-                visit_kind(value, visitor);
+                visit_kind(visitor, kind, name, components);
             }
+            visitor(VisitKind::FixedArrayEnd);
         }
         ValueKind::Array(value) => {
-            visitor(VisitKind::ArrayStart);
-            visit_kind(value, visitor);
+            visitor(VisitKind::ArrayStart(name));
+            visit_kind(visitor, value, name, components);
             visitor(VisitKind::ArrayEnd);
         }
-        value => visitor(VisitKind::Value(value)),
+        value => {
+            assert!(components.is_empty());
+            visitor(VisitKind::Leaf(value, name));
+        }
     }
 }
 
@@ -62,5 +100,111 @@ pub fn visit_value<'a>(value: &'a Value, visitor: &mut impl FnMut(VisitValue<'a>
             visitor(VisitValue::ArrayEnd);
         }
         value => visitor(VisitValue::Value(value)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solabi::abi::EventDescriptor;
+
+    fn parse_field(s: &str) -> Field {
+        EventDescriptor::parse_declaration(&format!("event Event({s})"))
+            .unwrap()
+            .inputs
+            .into_iter()
+            .next()
+            .unwrap()
+            .field
+    }
+
+    fn collect_visits(field: &Field) -> Vec<VisitKind> {
+        let mut visits = Vec::<VisitKind>::new();
+        let mut visitor = |visit| {
+            visits.push(visit);
+        };
+        visit_field(&mut visitor, field);
+        visits
+    }
+
+    #[test]
+    fn leaf() {
+        let field = "bool b0";
+        let field = dbg!(parse_field(field));
+        let visits = collect_visits(&field);
+        let expected = &[VisitKind::Leaf(&ValueKind::Bool, "b0")];
+        assert_eq!(&visits, expected);
+    }
+
+    #[test]
+    fn anonymous_tuple() {
+        let field = "(bool b0, bool)";
+        let field = dbg!(parse_field(field));
+        let visits = collect_visits(&field);
+        let expected = &[
+            VisitKind::TupleStart(""),
+            VisitKind::Leaf(&ValueKind::Bool, "b0"),
+            VisitKind::Leaf(&ValueKind::Bool, ""),
+            VisitKind::TupleEnd,
+        ];
+        assert_eq!(&visits, expected);
+    }
+
+    #[test]
+    fn named_tuple() {
+        let field = "(bool b0, bool) tuple0";
+        let field = dbg!(parse_field(field));
+        let visits = collect_visits(&field);
+        let expected = &[
+            VisitKind::TupleStart("tuple0"),
+            VisitKind::Leaf(&ValueKind::Bool, "b0"),
+            VisitKind::Leaf(&ValueKind::Bool, ""),
+            VisitKind::TupleEnd,
+        ];
+        assert_eq!(&visits, expected);
+    }
+
+    #[test]
+    fn fixed_array() {
+        let field = "bool[2][3] a0";
+        let field = dbg!(parse_field(field));
+        let visits = collect_visits(&field);
+        let expected = &[
+            VisitKind::FixedArrayStart(3, "a0"),
+            VisitKind::FixedArrayStart(2, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::FixedArrayEnd,
+            VisitKind::FixedArrayStart(2, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::FixedArrayEnd,
+            VisitKind::FixedArrayStart(2, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "a0"),
+            VisitKind::FixedArrayEnd,
+            VisitKind::FixedArrayEnd,
+        ];
+        assert_eq!(&visits, expected);
+    }
+
+    #[test]
+    fn complex() {
+        let field = "(bool b0, (bool b1) t0)[1][1] a0";
+        let field = dbg!(parse_field(field));
+        let visits = collect_visits(&field);
+        let expected = &[
+            VisitKind::FixedArrayStart(1, "a0"),
+            VisitKind::FixedArrayStart(1, "a0"),
+            VisitKind::TupleStart("a0"),
+            VisitKind::Leaf(&ValueKind::Bool, "b0"),
+            VisitKind::TupleStart("t0"),
+            VisitKind::Leaf(&ValueKind::Bool, "b1"),
+            VisitKind::TupleEnd,
+            VisitKind::TupleEnd,
+            VisitKind::FixedArrayEnd,
+            VisitKind::FixedArrayEnd,
+        ];
+        assert_eq!(&visits, expected);
     }
 }

--- a/src/database/keywords.rs
+++ b/src/database/keywords.rs
@@ -1,5 +1,5 @@
 /// Table and column names can't be these words in any capitalization.
-pub const SQLITE_KEYWORDS: &[&str] = &[
+pub const KEYWORDS: &[&str] = &[
     "abort",
     "action",
     "add",

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -2,7 +2,9 @@
 // - Implement this for Postgres in addition to Sqlite. Postgres will likely have a native async backend, so we should have the trait be async and internally `spawn_blocking` for use of non async rusqlite.
 // - Think about whether the trait should be Send + Sync and whether methods should take mutable Self.
 
+mod event_to_tables;
 mod event_visitor;
+mod keywords;
 mod sqlite;
 
 pub use self::sqlite::Sqlite;


### PR DESCRIPTION
Related to https://github.com/cowprotocol/arak/issues/38. This PR adds back the naming of column names after field names. It doesn't followed the linked issue exactly because I was working on this before Nick posted it and implementing the full thing is more work. The version in this PR gets us 80% of the way there by using field names whenever possible. This PR does the following things, that can still be improved later:

- It does not have the same "path naming" as in the issue for values that are inside tuples and arrays.
- It adds the a field index after every column name. For example `event Event(bool foo, bool bar)` turns into columns `foo_0` and `bar_1`. This is needed to support anonymous fields and fields that would map to the same name. This can be improved by only doing this when it is actually necessary. Currently it happens for all fields.

Look at the tests in `src/database/event_to_tables.rs` for examples.

As I said, this is 80% of the way. I want to think more about what the best naming scheme is before continuing.