### PR TITLE
[Logging] Disable Ansi

### DIFF
--- a/.github/workflows/deploy-google.yaml
+++ b/.github/workflows/deploy-google.yaml
@@ -1,0 +1,33 @@
+name: Deploy to Google Cloud
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Set up docker auth
+        run: gcloud auth configure-docker
+
+      - name: Build and Push Docker Image
+        run: |
+          IMAGE_NAME=gcr.io/eth-cloud-mb/arak:latest
+          DOCKERFILE_PATH=docker/Dockerfile
+
+          docker build -t $IMAGE_NAME -f $DOCKERFILE_PATH .
+          docker push $IMAGE_NAME

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,14 @@ struct Arguments {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-
     let args = Arguments::parse();
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter("info,arak=debug")
+        .with_ansi(false)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
     let (config, root) = Config::load(&args.config).context("failed to load configuration")?;
     env::set_current_dir(root)?;
 


### PR DESCRIPTION
Google cloud logs do not support "rich text" formats (like the default couloured ansi used by tracing_subscriber).

So our logs looked like this:

```
"[2m2023-09-25T08:24:51.500685Z[0m [34mDEBUG[0m [2marak::indexer[0m[2m:[0m fetched logs [3mevent[0m[2m=[0merc721_transfer [3mlogs[0m[2m=[0m265515"
```

which is gross.

This PR disables ansi (while also setting a default log level).

This means we no longer have to write

```sh
RUST_LOG=debug,arak=debug cargo run
```

but rather just 

```sh
cargo run
```

Not sure if this is actually desired since we have now hard coded the log level... although I cant imagine using any thing else here. Feel free to suggest removal of this.

