### PR TITLE
Better Debug Logging & Null Byte Bug Fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NODE_URL=https://rpc.ankr.com/eth
+
+# DB credentials created with `docker-compose up`
+DB_STRING=postgresql://arak:123@localhost:5432/postgres

--- a/.github/workflows/deploy-google.yaml
+++ b/.github/workflows/deploy-google.yaml
@@ -1,0 +1,33 @@
+name: Deploy to Google Cloud
+
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Set up docker auth
+        run: gcloud auth configure-docker
+
+      - name: Build and Push Docker Image
+        run: |
+          IMAGE_NAME=gcr.io/eth-cloud-mb/arak:latest
+          DOCKERFILE_PATH=docker/Dockerfile
+
+          docker build -t $IMAGE_NAME -f $DOCKERFILE_PATH .
+          docker push $IMAGE_NAME

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /arak.toml
+/.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dotenv",
  "ethrpc",
  "futures",
  "hex-literal",
@@ -283,6 +284,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ url = { version = "2", features = ["serde"] }
 futures = "0.3"
 tokio-postgres = "0.7"
 pg_bigdecimal = "0.1.5"
+dotenv = "0.15.0"
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -1,0 +1,12 @@
+RESOURCE_FILES = values.yaml
+
+delete:
+	kontemplate delete $(RESOURCE_FILES)
+
+apply:
+	kontemplate apply $(RESOURCE_FILES)
+
+hard-restart: delete apply
+
+restart:
+	kubectl rollout restart deployment arak-indexer

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,31 @@
+## Basic Usage (with kontemplate)
+
+Install [kontemplate](https://code.tvl.fyi/tree/ops/kontemplate)
+
+From within this directory
+
+### Delete Pod and Restart
+
+```sh
+kontemplate delete values.yaml
+kontemplate apply values.yaml
+```
+
+or use the make file
+
+```shell
+make hard-restart
+```
+
+to check status and observe logs:
+
+```sh
+kubectl get pods
+kubectl logs -f [POD_NAME]
+```
+
+or, for convenience:
+
+```shell
+kubectl logs -f $( kubectl get pods | grep arak-indexer | awk '{print $1}')
+```

--- a/kubernetes/config/configmap.yaml
+++ b/kubernetes/config/configmap.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .ConfigMapName }}
+  namespace: {{ .Namespace }}
+data:
+  arak.toml: |
+
+    [indexer]
+    page-size = 2000
+    poll-interval = 0.1
+
+    ## ERC721: https://eips.ethereum.org/EIPS/eip-721#specification
+    [[event]]
+    name = "erc721_transfer"
+    start = 0
+    contract = "*"
+    signature = "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)"
+
+    [[event]]
+    name = "erc721_approval"
+    start = 0
+    contract = "*"
+    signature = "event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)"
+
+    ## ERC1155: https://eips.ethereum.org/EIPS/eip-1155#specification
+    [[event]]
+    name = "erc1155_transfer_single"
+    start = 0
+    contract = "*"
+    signature = "event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value)"
+
+    [[event]]
+    name = "erc1155_transfer_batch"
+    start = 0
+    contract = "*"
+    signature = "event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values)"
+
+    [[event]]
+    name = "erc1155_uri"
+    start = 0
+    contract = "*"
+    signature = "event URI(string value, uint256 indexed id)"
+
+    ### Overlapping Events
+    [[event]]
+    name = "approval_for_all"
+    start = 0
+    contract = "*"
+    signature = "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)"
+
+    #[[event]]
+    #name = "indexed_approval_for_all"
+    #start = 0
+    #contract = "*"
+    #signature = "event ApprovalForAll (index_topic_1 address _owner, index_topic_2 address _operator, index_topic_3 bool _approved)"

--- a/kubernetes/config/pod.yaml
+++ b/kubernetes/config/pod.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .ProjectName }}-indexer
+  namespace: {{ .Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .ProjectName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .ProjectName }}
+    spec:
+      containers:
+      - name: {{ .ProjectName }}
+        image: {{ .ContainerRepo }}/{{ .ProjectName }}:{{ .ImageTag }}
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: config-volume
+          mountPath: {{ .ConfigPath }}/{{ .ConfigFile }}
+          subPath: {{ .ConfigFile }}
+        env:
+          - name: ARAKCONFIG
+            value: {{ .ConfigPath }}/{{ .ConfigFile }}
+
+          - name: NODE_URL
+            valueFrom:
+              secretKeyRef:
+                name: {{ .ProjectName }}-secrets
+                key: NODE_URL
+          - name: DB_STRING
+            valueFrom:
+              secretKeyRef:
+                name: {{ .ProjectName }}-secrets
+                key: DB_STRING
+      volumes:
+      - name: config-volume
+        configMap:
+          name: {{ .ProjectName }}-config

--- a/kubernetes/config/secrets.yaml
+++ b/kubernetes/config/secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: arak-secrets
+type: Opaque
+data:
+  NODE_URL: DO_NOT_ACTUALLY_PUT_SECRETS_HERE
+  DB_STRING: DO_NOT_ACTUALLY_PUT_SECRETS_HERE

--- a/kubernetes/values.yaml
+++ b/kubernetes/values.yaml
@@ -1,0 +1,17 @@
+global:
+  Namespace: default
+  ConfigMapName: arak-config
+  PodName: arak-indexer
+  ContainerRepo: ghcr.io/mintbase
+  ProjectName: arak
+  ImageTag: latest
+  ConfigFile: arak.toml
+  ConfigPath: /conf
+
+include:
+  # Notice how secrets are not explicitly included.
+  # This is because you should kubectl create and apply them
+  - name: "deployment"
+    path: "config/pod.yaml"
+  - name: "map"
+    path: "config/configmap.yaml"

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ fn manual_override(
         toml_values.insert("ethrpc".to_string(), Value::String(ethrpc));
     }
     if let Some(connection) = db_url {
-        tracing::info!("using env DB_URL");
+        tracing::info!("using env DB_STRING");
         let mut db_data = Table::new();
         db_data.insert("connection".to_string(), Value::String(connection.clone()));
         let mut db_type = Table::new();

--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -335,7 +335,9 @@ impl Postgres {
                         .collect::<Vec<_>>(),
                 ),
                 VisitValue::Value(AbiValue::Bytes(v)) => Box::new(v.to_owned()),
-                VisitValue::Value(AbiValue::String(v)) => Box::new(v.to_string()),
+                VisitValue::Value(AbiValue::String(v)) => {
+                    Box::new(v.trim_matches('\0').to_string())
+                }
                 _ => unreachable!(),
             };
             (if in_array {
@@ -562,7 +564,7 @@ event Event (
             fields: vec![
                 AbiValue::Bool(true),
                 AbiValue::Bool(false),
-                AbiValue::String("zef".to_string()),
+                AbiValue::String("zef with trailing null bytes\0".to_string()),
             ],
             ..Default::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use database::Database;
-
+use dotenv::dotenv;
 mod config;
 mod database;
 mod indexer;
@@ -15,14 +15,20 @@ use {
 struct Arguments {
     #[clap(short, long, env = "ARAKCONFIG", default_value = "arak.toml")]
     config: PathBuf,
+    #[clap(short, long, env = "DB_STRING")]
+    db_string: Option<String>,
+    #[clap(short, long, env = "NODE_URL")]
+    node_url: Option<String>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-
+    dotenv().ok(); // Couldn't load multiple Env Vars without this!
     let args = Arguments::parse();
-    let (config, root) = Config::load(&args.config).context("failed to load configuration")?;
+
+    let (config, root) = Config::load(&args.config, args.node_url, args.db_string)
+        .context("failed to load configuration")?;
     env::set_current_dir(root)?;
 
     match &config.database {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,9 +23,13 @@ struct Arguments {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
     dotenv().ok(); // Couldn't load multiple Env Vars without this!
     let args = Arguments::parse();
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_ansi(false)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     let (config, root) = Config::load(&args.config, args.node_url, args.db_string)
         .context("failed to load configuration")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
     dotenv().ok(); // Couldn't load multiple Env Vars without this!
     let args = Arguments::parse();
     let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_env_filter(env::var("RUST_LOGS").unwrap_or("info,arak=debug".to_string()))
         .with_ansi(false)
         .finish();
 


### PR DESCRIPTION
This PR accomplishes two things:

1. Adding relevant context to Debug logging (pointing to the specific offending event) on `store_event` error:

So before we were seeing: `Error: store_event` while now we see
```
 Error: store_event Log { event: "erc1155_uri", block_number: 15275205, log_index: 137, transaction_index: 46, address: Address(0x495f947276749Ce646f68AC8c248420045cb7b5e), fields: [String("\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0 \0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\u{1}\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"), Uint(Uint(BitWidth(256), 85244680541858928040054182450164838257542484891320981406559063124705063993345))] }
 ```
 which uniquely identifies the offending Log.
 
 2. Replaces `trim` null bytes with `replace` null bytes (so we don't miss internal null bytes - like in the updated test example).
 
 
 ## Test Plan
 
Altered test now passes.